### PR TITLE
Store channels in dict to cater for gaps in indices

### DIFF
--- a/pmatic/entities.py
+++ b/pmatic/entities.py
@@ -171,7 +171,7 @@ class Channel(utils.LogMixin, Entity):
         unknown channel needs to be created a debug message is being logged.
 
         The list of the created channels is then returned."""
-        channel_objects = []
+        channel_objects = {}
         for channel_dict in channel_dicts:
             channel_class = channel_classes_by_type_name.get(channel_dict["type"], Channel)
 
@@ -179,7 +179,7 @@ class Channel(utils.LogMixin, Entity):
                 cls.cls_logger().debug("Using generic Channel class (Type: %s): %r" %
                                                     (channel_dict["type"], channel_dict))
 
-            channel_objects.append(channel_class(device, channel_dict))
+            channel_objects[channel_dict["index"]] = channel_class(device, channel_dict)
         return channel_objects
 
 


### PR DESCRIPTION
Hi, first let me thank you for your nice work! I'm trying to contribute to this project with my HomeMatic setup. I'm working on Windows and tried to run the basic 'list all devices and channels with their values' scenario.

I found that some devices don't have continues channel numbers, for example the device HM-TC-IT-WM-W-EU:
Kanaltyp Kanalnummer
WEATHER_TRANSMIT 1
THERMALCONTROL_TRANSMIT 2
WINDOW_SWITCH_RECEIVER 3
REMOTECONTROL_RECEIVER 6
SWITCH_TRANSMIT 7

Channels 4-5 don't exist for this device. This is a problem because the code at https://github.com/LarsMichelsen/pmatic/blob/604f2736daeadf98930e1c8888cf09d1e967e2ad/pmatic/entities.py#L182 assumes that all channels have continues indices, e.g. channel index equals array index. Later on this will fail because when accessing the channel index 6 for this device it will fail because the array will contain only 5 channels.

Solution would be to store the channels in a dictionary with the channel numbers/index as key.