### PR TITLE
Rh/new devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ start-manager
 dist/pmatic-*.tar.gz
 dist/ccu
 playground.py
+.idea

--- a/doc/pmatic_devices.rst
+++ b/doc/pmatic_devices.rst
@@ -55,6 +55,24 @@ HM-ES-PMSw1-Pl (Funk-Schaltaktor mit Leistungsmessung)
     :undoc-members:
     :exclude-members: type_name
 
+HM-LC-Sw1-Pl-DN-R1 (Funk-Schaltaktor ohne Leistungsmessung)
+--------------------------------------------------------------------
+
+.. autoclass:: pmatic.entities.HM_LC_Sw1_Pl_DN_R1
+    :show-inheritance:
+    :members:
+    :undoc-members:
+    :exclude-members: type_name
+
+HM-LC-Bl1PBU-FM (Funk-Rolladenaktor unterputz)
+--------------------------------------------------------------------
+
+.. autoclass:: pmatic.entities.HM_LC_Bl1PBU_FM
+    :show-inheritance:
+    :members:
+    :undoc-members:
+    :exclude-members: type_name
+
 HM-PBI-4-FM (Funk-Tasterschnittstelle 4-fach)
 --------------------------------------------------------
 
@@ -68,6 +86,24 @@ HM-WDS10-TH-O (Funk-Temperatur-/Luftfeuchtesensor OTH)
 --------------------------------------------------------
 
 .. autoclass:: pmatic.entities.HM_WDS10_TH_O
+    :show-inheritance:
+    :members:
+    :undoc-members:
+    :exclude-members: type_name
+
+HM-WDS40-TH-I-2 (Funk-Temperatur-/Luftfeuchtesensor ITH)
+--------------------------------------------------------
+
+.. autoclass:: pmatic.entities.HM_WDS40_TH_I_2
+    :show-inheritance:
+    :members:
+    :undoc-members:
+    :exclude-members: type_name
+
+HM-Sen-LI-O (Funk-Außen-Helligkeitssensor OLI)
+--------------------------------------------------------
+
+.. autoclass:: pmatic.entities.HM_Sen_LI_O
     :show-inheritance:
     :members:
     :undoc-members:
@@ -93,6 +129,15 @@ ChannelShutterContact
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: pmatic.entities.ChannelShutterContact
+    :show-inheritance:
+    :members:
+    :undoc-members:
+    :exclude-members: type_name
+
+ChannelBlind
+^^^^^^^^^^^^
+
+.. autoclass:: pmatic.entities.ChannelBlind
     :show-inheritance:
     :members:
     :undoc-members:

--- a/pmatic/entities.py
+++ b/pmatic/entities.py
@@ -509,12 +509,12 @@ class ChannelBlind(Channel):
         return self.values["LEVEL"].value
 
     def set_level(self, level):
-        """Look up the level at which the shutter is set."""
+        """Set the level at which the shutter is to be set."""
         return self.values["LEVEL"].set(level)
 
     @property
     def working(self):
-        """Look up the level at which the shutter is set."""
+        """Look up the WORKING value."""
         return self.values["WORKING"].value
 
 

--- a/pmatic/entities.py
+++ b/pmatic/entities.py
@@ -499,6 +499,26 @@ class ChannelShutterContact(Channel):
 
 
 
+# FIXME: Handle STOP, INHIBIT, INSTALL_TEST
+class ChannelBlind(Channel):
+    type_name = "BLIND"
+
+    @property
+    def level(self):
+        """Look up the level at which the shutter is set."""
+        return self.values["LEVEL"].value
+
+    def set_level(self, level):
+        """Look up the level at which the shutter is set."""
+        return self.values["LEVEL"].set(level)
+
+    @property
+    def working(self):
+        """Look up the level at which the shutter is set."""
+        return self.values["WORKING"].value
+
+
+
 # FIXME: Handle INHIBIT, WORKING
 class ChannelSwitch(Channel):
     type_name = "SWITCH"
@@ -600,6 +620,13 @@ class ChannelConditionVoltage(Channel):
 class ChannelConditionFrequency(Channel):
     type_name = "CONDITION_FREQUENCY"
 
+
+
+# FIXME: To be implemented.
+# Devices:
+#   HM-Sen-LI-O
+class ChannelLuxmeter(Channel):
+    type_name = "LUXMETER"
 
 
 # FIXME: To be implemented.
@@ -1308,6 +1335,43 @@ class HM_WDS10_TH_O(Device):
 
 
 
+# Funk-Temperatur-/Luftfeuchtesensor ITH
+class HM_WDS40_TH_I_2(Device):
+    type_name = "HM-WDS40-TH-I-2"
+
+    @property
+    def temperature(self):
+        """Provides the current temperature.
+
+        Returns an instance of :class:`ParameterFLOAT`.
+        """
+        return self.channels[1].values["TEMPERATURE"]
+
+
+    @property
+    def humidity(self):
+        """Provides the current humidity.
+
+        Returns an instance of :class:`ParameterFLOAT`.
+        """
+        return self.channels[1].values["HUMIDITY"]
+
+
+
+# Funk-Außen-Helligkeitssensor OLI
+class HM_Sen_LI_O(Device):
+    type_name = "HM-Sen-LI-O"
+
+    @property
+    def brightness(self):
+        """Provides the current brightness.
+
+        Returns an instance of :class:`ParameterFLOAT`.
+        """
+        return self.channels[1].values["LUX"]
+
+
+
 # Virtuelle Fernbedienung der CCU
 class HM_RCV_50(Device):
     type_name = "HM-RCV-50"
@@ -1346,6 +1410,49 @@ class HM_ES_PMSw1_Pl(Device):
         return super(HM_ES_PMSw1_Pl, self)._get_summary_state(
             skip_channel_types=["ChannelConditionPower", "ChannelConditionCurrent",
                                 "ChannelConditionVoltage", "ChannelConditionFrequency"])
+
+
+
+# Funk-Schaltaktor ohne Leistungsmessung
+class HM_LC_Sw1_Pl_DN_R1(Device):
+    type_name = "HM-LC-Sw1-Pl-DN-R1"
+
+
+    # Make methods of ChannelSwitch() available
+    def __getattr__(self, attr):
+        return getattr(self.channels[1], attr)
+
+
+    @property
+    def summary_state(self):
+        return super(HM_LC_Sw1_Pl_DN_R1, self)._get_summary_state()
+
+    @property
+    def switch(self):
+        """Provides to the :class:`.ChannelKey` object of the switch.
+
+        You can do something like ``self.switch.switch_on()`` with this. For details take
+        a look at the methods provided by the :class:``.ChannelKey`` class."""
+        return self.channels[1]
+
+
+
+# Funk-Rolladenaktor
+class HM_LC_Bl1PBU_FM(Device):
+    type_name = "HM-LC-Bl1PBU-FM"
+
+
+    # Make methods of ChannelBlind() available
+    def __getattr__(self, attr):
+        return getattr(self.channels[1], attr)
+
+    @property
+    def blind(self):
+        """Provides to the :class:`.ChannelKey` object of the blind channel.
+
+        You can do something like ``self.blind.set_level(0.6)`` with this. For details take
+        a look at the methods provided by the :class:``.ChannelKey`` class."""
+        return self.channels[1]
 
 
 


### PR DESCRIPTION
Hello Lars,

This is my second pull request, this time dealing with my additions to entities.py. I added the channel "ChannelBlind" and device classes for 
- HM_WDS40_TH_I_2
- HM_Sen_LI_O
- HM_LC_Sw1_Pl_DN_R1 and
- HM_LC_Bl1PBU_FM

They all work with my Homematic hardware. I tested them both on my PC (Windows 7 and Linux) and the CCU2.

Best regards,
 Rolf